### PR TITLE
Increase page size in BookController

### DIFF
--- a/eCommerce/Controllers/BookController.cs
+++ b/eCommerce/Controllers/BookController.cs
@@ -11,7 +11,7 @@ public class BookController(BookShopDbContext context) : Controller
 
     public async Task<IActionResult> Index(int page = 1, string? sortField = null, string? sortDir = null, string? searchTerm = null)
     {
-        const int pageSize = 3; // Products per page (easily changeable)
+        const int pageSize = 10; // Products per page
 
         sortField ??= "Title"; // default sort
         sortDir = string.Equals(sortDir, "desc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc";


### PR DESCRIPTION
Closes #30

This pull request makes a small change to the pagination of the book listing in the `BookController`. The number of products displayed per page has been increased from 3 to 10.